### PR TITLE
Check environment variable for events directory if not set through configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Detailled instructions on SPI installation can be found in the [keycloak docs](h
 Also make sure to check out the [`Dockerfile`](Dockerfile).
 ### Configure SPI
 The SPI requires you to provide a configuration option describing where to write the event counter files.
+#### Configuring in standalone.xml
 SPI configuration happens in keycloaks `standalone.xml`.
 Within `<subsystem xmlns="urn:jboss:domain:keycloak-server:1.1"></subsystem>` you need to add the following lines:
 ```xml
@@ -34,6 +35,9 @@ Within `<subsystem xmlns="urn:jboss:domain:keycloak-server:1.1"></subsystem>` yo
 </spi>
 ```
 For a more advanced example (directory name read from env variable) see the [`Dockerfile`](Dockerfile) again.
+#### Configuring using an environment variable
+The metrics directory can be specified by setting the `KEYCLOAK_PROMETHEUS_EVENTS_DIR` environment variable.
+This value will only be used if the `eventsDirectory` configuration value is not set or if it is an empty string.
 ### Configuration in keycloak
 ![setup](setup.png)
 In keycloak's admin console under `Events > Config` you need to add `com.larscheidschmitzhermes:keycloak-monitoring-prometheus` as an Event Listener.

--- a/src/main/java/com/larscheidschmitzhermes/keycloak/events/MonitoringEventListenerProviderFactory.java
+++ b/src/main/java/com/larscheidschmitzhermes/keycloak/events/MonitoringEventListenerProviderFactory.java
@@ -1,5 +1,6 @@
 package com.larscheidschmitzhermes.keycloak.events;
 
+import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
@@ -7,6 +8,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
 public class MonitoringEventListenerProviderFactory implements EventListenerProviderFactory {
+    private static final Logger logger = Logger.getLogger(MonitoringEventListenerProviderFactory.class);
     private final String EVENTS_DIRECTORY_ENV = "KEYCLOAK_PROMETHEUS_EVENTS_DIR";
 
     private String eventsDirectory;
@@ -20,9 +22,12 @@ public class MonitoringEventListenerProviderFactory implements EventListenerProv
     public void init(Config.Scope config) {
         String eventsDirectoryConfigVal = config.get("eventsDirectory");
         if (eventsDirectoryConfigVal != null && !eventsDirectoryConfigVal.isEmpty()) {
+            logger.debug("Using events directory from configuration file: " + eventsDirectoryConfigVal);
             this.eventsDirectory = eventsDirectoryConfigVal;
         } else {
-            this.eventsDirectory = System.getenv(EVENTS_DIRECTORY_ENV);
+            String eventsDirectoryEnvVal = System.getenv(EVENTS_DIRECTORY_ENV);
+            logger.debug("Using events directory from " + EVENTS_DIRECTORY_ENV + " environment variable: " + eventsDirectoryEnvVal);
+            this.eventsDirectory = eventsDirectoryEnvVal;
         }
     }
 

--- a/src/main/java/com/larscheidschmitzhermes/keycloak/events/MonitoringEventListenerProviderFactory.java
+++ b/src/main/java/com/larscheidschmitzhermes/keycloak/events/MonitoringEventListenerProviderFactory.java
@@ -7,8 +7,9 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
 public class MonitoringEventListenerProviderFactory implements EventListenerProviderFactory {
-    private String eventsDirectory;
+    private final String EVENTS_DIRECTORY_ENV = "KEYCLOAK_PROMETHEUS_EVENTS_DIR";
 
+    private String eventsDirectory;
 
     @Override
     public EventListenerProvider create(KeycloakSession session) {
@@ -17,7 +18,12 @@ public class MonitoringEventListenerProviderFactory implements EventListenerProv
 
     @Override
     public void init(Config.Scope config) {
-        this.eventsDirectory = config.get("eventsDirectory");
+        String eventsDirectoryConfigVal = config.get("eventsDirectory");
+        if (eventsDirectoryConfigVal != null && !eventsDirectoryConfigVal.isEmpty()) {
+            this.eventsDirectory = eventsDirectoryConfigVal;
+        } else {
+            this.eventsDirectory = System.getenv(EVENTS_DIRECTORY_ENV);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi @tobilarscheid , would you mind taking a look?

Currently a change must be made to the configuration file in keycloak
to decide which directory the metrics data should be stored within.
An environment variable can be specified in the configuration, however
this still requires the configuration file to be modified.

This change will check an environment variable if no config value has
been provided. This allows the location of the metrics to be changed
without modifying any of the files within the original keycloak image.

Would this be something you'd be interested in including in the project?
I have found this quite useful as the work I have been doing made
modifying the keycloak configuration files a hassle.