### PR TITLE
Create jboss-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM jboss/keycloak:3.2.1.Final
-RUN sed -ie 's|<subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">|<subsystem xmlns="urn:jboss:domain:keycloak-server:1.1"><spi name="eventsListener"><provider name="com.larscheidschmitzhermes:keycloak-monitoring-prometheus" enabled="true"><properties><property name="eventsDirectory" value="${env.EVENTS_DIRECTORY:/metrics}"/></properties></provider></spi>|g' /opt/jboss/keycloak/standalone/configuration/standalone.xml
+FROM jboss/keycloak:7.0.0
+COPY jboss-cli /opt/jboss/startup-scripts/prometheus.cli
+RUN /opt/jboss/keycloak/bin/run-cli.sh --file=/opt/jboss/startup-scripts/prometheus.cli
 COPY build/libs/*.jar keycloak/providers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM jboss/keycloak:7.0.0
-COPY jboss-cli /opt/jboss/startup-scripts/prometheus.cli
-RUN /opt/jboss/keycloak/bin/run-cli.sh --file=/opt/jboss/startup-scripts/prometheus.cli
+COPY jboss-cli /opt/jboss/tools/prometheus.cli
+RUN /opt/jboss/keycloak/bin/jboss-cli.sh --file=/opt/jboss/tools/prometheus.cli
 COPY build/libs/*.jar keycloak/providers/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ This value will only be used if the `eventsDirectory` configuration value is not
 ![setup](setup.png)
 In keycloak's admin console under `Events > Config` you need to add `com.larscheidschmitzhermes:keycloak-monitoring-prometheus` as an Event Listener.
 Make sure you do this for every realm you want to monitor!
+#### Configuring using Keycloak CLI
+Keycloak supports scripting of configuration changes via CLI. This has the benefit of decoupling configuration changes from the deployed keycloak version allowing easy upgrades of binaries. This is especially beneficial in a containerized environment.
+### Using CLI to configure Keycloak
+To configure the Prometheus exporter via CLI add the content of [`jboss-cli`](jboss-cli) to `<path to your installation>/keycloak-server/jboss-cli/startup-scripts/startup-standalone.cli`. During startup of Keycloak the cli will add the configuration entries to `standalone.xml`
+For more information refer to [`Keycloak documentation`](https://www.keycloak.org/docs/7.0/server_installation/#cli-scripting)
+
 ### Getting your metrics into prometheus
 Once everything is setup in keycloak, you will start seeing files like `keycloak_admin_events_total;realm=master;operation=CREATE;resource=USER` in your configured events directory.
 These files contain a number stating how often an event with the given parameters was emitted.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Make sure you do this for every realm you want to monitor!
 #### Configuring using Keycloak CLI
 Keycloak supports scripting of configuration changes via CLI. This has the benefit of decoupling configuration changes from the deployed keycloak version allowing easy upgrades of binaries. This is especially beneficial in a containerized environment.
 ### Using CLI to configure Keycloak
-To configure the Prometheus exporter via CLI add the content of [`jboss-cli`](jboss-cli) to `<path to your installation>/keycloak-server/jboss-cli/startup-scripts/startup-standalone.cli`. During startup of Keycloak the cli will add the configuration entries to `standalone.xml`
+To configure the Prometheus exporter via CLI see [`Dockerfile`](Dockerfile).
+The content of [`jboss-cli`](jboss-cli) is added with `jboss-cli.sh` and `embed-server mode`. During docker build you will see Keycloak adding the configuration entries to `standalone.xml`.
 For more information refer to [`Keycloak documentation`](https://www.keycloak.org/docs/7.0/server_installation/#cli-scripting)
 
 ### Getting your metrics into prometheus

--- a/jboss-cli
+++ b/jboss-cli
@@ -1,2 +1,4 @@
+embed-server --server-config=standalone.xml --std-out=echo
 /subsystem=keycloak-server/spi=eventsListener: add()
 /subsystem=keycloak-server/spi=eventsListener/provider="com.larscheidschmitzhermes:keycloak-monitoring-prometheus": add(enabled=true,properties={eventsDirectory=/metrics})
+stop-embedded-server

--- a/jboss-cli
+++ b/jboss-cli
@@ -1,0 +1,2 @@
+/subsystem=keycloak-server/spi=eventsListener: add()
+/subsystem=keycloak-server/spi=eventsListener/provider="com.larscheidschmitzhermes:keycloak-monitoring-prometheus": add(enabled=true,properties={eventsDirectory=/metrics})


### PR DESCRIPTION
For Keycloak 6.x  cli interface is the proposed way to configure. The file is setting the exporter config